### PR TITLE
Create Django templatetags

### DIFF
--- a/src/django_idom/static/js/idom.js
+++ b/src/django_idom/static/js/idom.js
@@ -1,0 +1,2 @@
+// Build.js is going to need to be moved here via your deployment scripts
+// This will allow developers to import IDOM the Django way

--- a/src/django_idom/templates/idom/head_content.html
+++ b/src/django_idom/templates/idom/head_content.html
@@ -1,0 +1,2 @@
+<!-- The importable IDOM JS -->
+<script src="{% static 'js/idom.js' %}" crossorigin="anonymous"></script>

--- a/src/django_idom/templates/idom/root.html
+++ b/src/django_idom/templates/idom/root.html
@@ -1,0 +1,4 @@
+<!-- Allows for making the IDOM root object the Django way
+    Developers will often opt not to use this,
+    but having this makes getting started a little bit easier to explain -->
+<div id="{{ html_id }}"></div>

--- a/src/django_idom/templatetags/idom.py
+++ b/src/django_idom/templatetags/idom.py
@@ -1,13 +1,14 @@
 from django import template
-from django.urls import reverse
 
 
 register = template.Library()
+
 
 # Template tag that renders the IDOM scripts
 @register.inclusion_tag("idom/head_content.html")
 def idom_scripts():
     pass
+
 
 # Template tag that renders an empty idom root object
 @register.inclusion_tag("idom/root.html")

--- a/src/django_idom/templatetags/idom.py
+++ b/src/django_idom/templatetags/idom.py
@@ -12,5 +12,5 @@ def idom_scripts():
 
 # Template tag that renders an empty idom root object
 @register.inclusion_tag("idom/root.html")
-def idom_root(html_id):
+def idom_view(html_id):
     return {"html_id": html_id}

--- a/src/django_idom/templatetags/tags.py
+++ b/src/django_idom/templatetags/tags.py
@@ -1,0 +1,15 @@
+from django import template
+from django.urls import reverse
+
+
+register = template.Library()
+
+# Template tag that renders the IDOM scripts
+@register.inclusion_tag("idom/head_content.html")
+def idom_scripts():
+    pass
+
+# Template tag that renders an empty idom root object
+@register.inclusion_tag("idom/root.html")
+def idom_root(html_id):
+    return {"html_id": html_id}


### PR DESCRIPTION
Barebones structure to allow for a user to simply type 

```jinja
{% load idom %}
<head>
   {% idom_scripts %}
</head>

<body>
   {% idom_view 'root' %}
</body>
```

to import IDOM into Django.

_note: these template tags are only registered if the user adds "django_idom" to `settings.py:INSTALLED_APPS`_

As I mentioned, there is gonna be some slight awkwardness to this due to build.js not being built directly to `django_idom/static/js/idom.js`. However, that can be resolved via modifying our deployment procedure.

I've included some HTML and JS comments just for our sake. We'll remove them before we merge this PR.

Alternatively, we can have `idom.js` point to JavaScript stored on a CDN somewhere rather than locally deploying. But, many Django users due prefer local files due to things such as `Django-Compressor` and `Django-Pipelines` though.