### PR TITLE
synchronize JS and Py version requirements for IDOM

### DIFF
--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,2 +1,2 @@
 channels<4.0.0 # Django websocket features
-idom<1.0.0 # Python React
+idom >=0.33.0, <0.34.0

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -18,6 +18,6 @@
     "rollup-plugin-replace": "^2.2.0"
   },
   "dependencies": {
-    "idom-client-react": "^0.8.5"
+    "idom-client-react": "^0.33.0"
   }
 }


### PR DESCRIPTION
The IDOM client and core libraries now have synchronized versions. To ensure they work correctly together we need to ensure the version requirements we use both are the same.