### PR TITLE
Component Initial HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ In context this will look a bit like the following...
 </html>
 ```
 
-Keyworded parameters that can also be passed in include `class="example"` and `loader="example.html"`
+Keyworded parameters that can also be passed in include `class="example"` and `initial_html="example.html"`
 
 ## `example_app/views.py`
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,8 @@ In context this will look a bit like the following...
 </html>
 ```
 
+Keyworded parameters that can also be passed in include `class="example"` and `loader="example.html"`
+
 ## `example_app/views.py`
 
 You can then serve `your-template.html` from a view just

--- a/src/django_idom/templates/idom/component.html
+++ b/src/django_idom/templates/idom/component.html
@@ -1,5 +1,5 @@
 {% load static %}
-<div id="{{ idom_mount_uuid }}" class="{{ class }}"></div>
+<div id="{{ idom_mount_uuid }}" class="{{ class }}">{% if loader %}{% include loader %}{% endif %}</div>
 <script type="module" crossorigin="anonymous">
   import { mountViewToElement } from "{% static 'js/django-idom-client.js' %}";
   const mountPoint = document.getElementById("{{ idom_mount_uuid }}");

--- a/src/django_idom/templates/idom/component.html
+++ b/src/django_idom/templates/idom/component.html
@@ -1,5 +1,5 @@
 {% load static %}
-<div id="{{ idom_mount_uuid }}" class="{{ class }}">{% if loader %}{% include loader %}{% endif %}</div>
+<div id="{{ idom_mount_uuid }}" class="{{ class }}">{% if initial_html %}{% include initial_html %}{% endif %}</div>
 <script type="module" crossorigin="anonymous">
   import { mountViewToElement } from "{% static 'js/django-idom-client.js' %}";
   const mountPoint = document.getElementById("{{ idom_mount_uuid }}");

--- a/src/django_idom/templatetags/idom.py
+++ b/src/django_idom/templatetags/idom.py
@@ -20,10 +20,12 @@ def idom_component(_component_id_, **kwargs):
     _register_component(_component_id_)
 
     class_ = kwargs.pop("class", "")
+    loader = kwargs.pop("loader", "")
     json_kwargs = json.dumps(kwargs, separators=(",", ":"))
 
     return {
         "class": class_,
+        "loader": loader,
         "idom_websocket_url": IDOM_WEBSOCKET_URL,
         "idom_web_modules_url": IDOM_WEB_MODULES_URL,
         "idom_ws_max_reconnect_delay": IDOM_WS_MAX_RECONNECT_DELAY,

--- a/src/django_idom/templatetags/idom.py
+++ b/src/django_idom/templatetags/idom.py
@@ -20,12 +20,12 @@ def idom_component(_component_id_, **kwargs):
     _register_component(_component_id_)
 
     class_ = kwargs.pop("class", "")
-    loader = kwargs.pop("loader", "")
+    initial_html = kwargs.pop("initial_html", "")
     json_kwargs = json.dumps(kwargs, separators=(",", ":"))
 
     return {
         "class": class_,
-        "loader": loader,
+        "initial_html": initial_html,
         "idom_websocket_url": IDOM_WEBSOCKET_URL,
         "idom_web_modules_url": IDOM_WEB_MODULES_URL,
         "idom_ws_max_reconnect_delay": IDOM_WS_MAX_RECONNECT_DELAY,


### PR DESCRIPTION
The idea of this PR is to allow for customizable initial HTML. 

This is useful for...
- Showing a simple loader/message in situations where a websocket connection could not be formed (Message display can be delayed via CSS).
- Can be used to run simple scripts on the component div.

This is different than an IDOM Core `idom.component` `fallback=...` that we have discussed due to the fact that this implementation fallback has no WS reliance.