### PR TITLE
Add "name" to WS and Web Module paths

### DIFF
--- a/src/django_idom/paths.py
+++ b/src/django_idom/paths.py
@@ -6,7 +6,9 @@ from .websocket_consumer import IdomAsyncWebsocketConsumer
 
 
 IDOM_WEBSOCKET_PATH = path(
-    IDOM_WEBSOCKET_URL + "<view_id>/", IdomAsyncWebsocketConsumer.as_asgi()
+    IDOM_WEBSOCKET_URL + "<view_id>/",
+    IdomAsyncWebsocketConsumer.as_asgi(),
+    name="idom_websocket",
 )
 """A URL resolver for :class:`IdomAsyncWebsocketConsumer`
 
@@ -17,7 +19,9 @@ to allow users to configure the URL themselves.
 
 
 IDOM_WEB_MODULES_PATH = path(
-    IDOM_WEB_MODULES_URL + "<path:file>", views.web_modules_file
+    IDOM_WEB_MODULES_URL + "<path:file>",
+    views.web_modules_file,
+    name="idom_web_modules",
 )
 """A URL resolver for static web modules required by IDOM
 

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -27,7 +27,6 @@ if IDOM_WEB_MODULE_CACHE is None:
         file_path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/"))
         return HttpResponse(file_path.read_text(), content_type="text/javascript")
 
-
 else:
     _web_module_cache = caches[IDOM_WEB_MODULE_CACHE]
 


### PR DESCRIPTION
Adding `name=...` to our paths allows for developers to use [django reverse](https://docs.djangoproject.com/en/3.2/ref/urlresolvers/#reverse) to obtain these URLs via name.