### PR TITLE
Improve Caching Schema

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, 3.10]
+        python-version: ["3.8", "3.9", "3.10"]
     steps:
       - uses: actions/checkout@v2
       - uses: nanasess/setup-chromedriver@master

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, 3.10]
     steps:
       - uses: actions/checkout@v2
       - uses: nanasess/setup-chromedriver@master

--- a/README.md
+++ b/README.md
@@ -106,10 +106,6 @@ You may configure additional options as well:
 # the base URL for all IDOM-releated resources
 IDOM_BASE_URL: str = "_idom/"
 
-# Set cache size limit for loading JS files for IDOM.
-# Only applies when not using Django's caching framework (see below).
-IDOM_WEB_MODULE_LRU_CACHE_SIZE: int | None = None
-
 # Maximum seconds between two reconnection attempts that would cause the client give up.
 # 0 will disable reconnection.
 IDOM_WS_MAX_RECONNECT_DELAY: int = 604800
@@ -117,9 +113,8 @@ IDOM_WS_MAX_RECONNECT_DELAY: int = 604800
 # Configure a cache for loading JS files
 CACHES = {
   # Configure a cache for loading JS files for IDOM
-  "idom_web_modules": {"BACKEND": ...},
-  # If the above cache is not configured, then we'll use the "default" instead
-  "default": {"BACKEND": ...},
+  # If "idom" cache is not configured, then we'll use the "default" instead
+  "idom": {"BACKEND": ...},
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,6 @@ IDOM_WS_MAX_RECONNECT_DELAY: int = 604800
 
 # Configure a cache for loading JS files
 CACHES = {
-  # Configure a cache for loading JS files for IDOM
   # If "idom" cache is not configured, then we'll use the "default" instead
   "idom": {"BACKEND": ...},
 }

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,3 +1,3 @@
-channels<4.0.0 # Django websocket features
+channels <4.0.0
 idom >=0.34.0, <0.35.0
 aiofile >=3.0, <4.0

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,2 +1,3 @@
 channels<4.0.0 # Django websocket features
 idom >=0.33.0, <0.34.0
+aiofile >=3.0, <4.0

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ package_dir = src_dir / name
 
 package = {
     "name": name,
-    "python_requires": ">=3.7",
+    "python_requires": ">=3.8",
     "packages": find_packages(str(src_dir)),
     "package_dir": {"": "src"},
     "description": "Control the web with Python",
@@ -52,15 +52,14 @@ package = {
     "zip_safe": False,
     "classifiers": [
         "Framework :: Django",
-        "Framework :: Django :: 3.1",
-        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Operating System :: OS Independent",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "Topic :: Multimedia :: Graphics",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Environment :: Web Environment",
     ],
 }

--- a/src/django_idom/config.py
+++ b/src/django_idom/config.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 from django.conf import settings
-from django.core.cache import DEFAULT_CACHE_ALIAS
+from django.core.cache import DEFAULT_CACHE_ALIAS, caches
 from idom.core.proto import ComponentConstructor
 
 
@@ -13,6 +13,6 @@ IDOM_WEB_MODULES_URL = IDOM_BASE_URL + "web_module/"
 IDOM_WS_MAX_RECONNECT_DELAY = getattr(settings, "IDOM_WS_MAX_RECONNECT_DELAY", 604800)
 
 if "idom" in getattr(settings, "CACHES", {}):
-    IDOM_CACHE = "idom"
+    IDOM_CACHE = caches["idom"]
 else:
-    IDOM_CACHE = DEFAULT_CACHE_ALIAS
+    IDOM_CACHE = caches[DEFAULT_CACHE_ALIAS]

--- a/src/django_idom/config.py
+++ b/src/django_idom/config.py
@@ -12,17 +12,7 @@ IDOM_WEBSOCKET_URL = IDOM_BASE_URL + "websocket/"
 IDOM_WEB_MODULES_URL = IDOM_BASE_URL + "web_module/"
 IDOM_WS_MAX_RECONNECT_DELAY = getattr(settings, "IDOM_WS_MAX_RECONNECT_DELAY", 604800)
 
-_CACHES = getattr(settings, "CACHES", {})
-if _CACHES:
-    if "idom_web_modules" in getattr(settings, "CACHES", {}):
-        IDOM_WEB_MODULE_CACHE = "idom_web_modules"
-    else:
-        IDOM_WEB_MODULE_CACHE = DEFAULT_CACHE_ALIAS
+if "idom" in getattr(settings, "CACHES", {}):
+    IDOM_CACHE = "idom"
 else:
-    IDOM_WEB_MODULE_CACHE = None
-
-
-# the LRU cache size for the route serving IDOM_WEB_MODULES_DIR files
-IDOM_WEB_MODULE_LRU_CACHE_SIZE = getattr(
-    settings, "IDOM_WEB_MODULE_LRU_CACHE_SIZE", None
-)
+    IDOM_CACHE = DEFAULT_CACHE_ALIAS

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -22,7 +22,7 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
 
     # Fetch the web modules file from cache, if available
     last_modified_time = os.stat(path).st_mtime
-    cache_key = f"django_idom:web_module:{path}"
+    cache_key = f"django_idom:web_module:{str(path).lstrip(str(web_modules_dir))}"
     response = await IDOM_CACHE.aget(cache_key, version=last_modified_time)
     if response is None:
         async with async_open(path, "r") as fp:

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -15,9 +15,11 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
     last_modified_time = os.stat(path).st_mtime
     cache_key = f"django_idom:{path}"
-    response = idom_cache.get(cache_key, version=last_modified_time)
+    response = await idom_cache.aget(cache_key, version=last_modified_time)
     if response is None:
         response = HttpResponse(path.read_text(), content_type="text/javascript")
-        idom_cache.delete(cache_key)
-        idom_cache.set(cache_key, response, timeout=None, version=last_modified_time)
+        await idom_cache.adelete(cache_key)
+        await idom_cache.aset(
+            cache_key, response, timeout=None, version=last_modified_time
+        )
     return response

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -1,7 +1,6 @@
 import os
 
 from aiofile import async_open
-from django.core.cache import caches
 from django.http import HttpRequest, HttpResponse
 from idom.config import IDOM_WED_MODULES_DIR
 

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -8,20 +8,17 @@ from idom.config import IDOM_WED_MODULES_DIR
 from .config import IDOM_CACHE
 
 
-idom_cache = caches[IDOM_CACHE]
-
-
 async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     """Gets JavaScript required for IDOM modules at runtime. These modules are
     returned from cache if available."""
     path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
     last_modified_time = os.stat(path).st_mtime
     cache_key = f"django_idom:web_module:{path}"
-    response = await idom_cache.aget(cache_key, version=last_modified_time)
+    response = await IDOM_CACHE.aget(cache_key, version=last_modified_time)
     if response is None:
         async with async_open(path, "r") as fp:
             response = HttpResponse(await fp.read(), content_type="text/javascript")
-        await idom_cache.aset(
+        await IDOM_CACHE.aset(
             cache_key, response, timeout=None, version=last_modified_time
         )
     return response

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -18,6 +18,7 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     if response is None:
         async with async_open(path, "r") as fp:
             response = HttpResponse(await fp.read(), content_type="text/javascript")
+        await IDOM_CACHE.adelete(cache_key)
         await IDOM_CACHE.aset(
             cache_key, response, timeout=None, version=last_modified_time
         )

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -1,43 +1,22 @@
-import asyncio
-import functools
 import os
 
 from django.core.cache import caches
 from django.http import HttpRequest, HttpResponse
 from idom.config import IDOM_WED_MODULES_DIR
 
-from .config import IDOM_WEB_MODULE_CACHE, IDOM_WEB_MODULE_LRU_CACHE_SIZE
+from .config import IDOM_CACHE
 
 
-if IDOM_WEB_MODULE_CACHE is None:
+idom_cache = caches[IDOM_CACHE]
 
-    def async_lru_cache(*lru_cache_args, **lru_cache_kwargs):
-        def async_lru_cache_decorator(async_function):
-            @functools.lru_cache(*lru_cache_args, **lru_cache_kwargs)
-            def cached_async_function(*args, **kwargs):
-                coroutine = async_function(*args, **kwargs)
-                return asyncio.ensure_future(coroutine)
 
-            return cached_async_function
-
-        return async_lru_cache_decorator
-
-    @async_lru_cache(IDOM_WEB_MODULE_LRU_CACHE_SIZE)
-    async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
-        file_path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/"))
-        return HttpResponse(file_path.read_text(), content_type="text/javascript")
-
-else:
-    _web_module_cache = caches[IDOM_WEB_MODULE_CACHE]
-
-    async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
-        file = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
-        last_modified_time = os.stat(file).st_mtime
-        cache_key = f"{file}:{last_modified_time}"
-
-        response = _web_module_cache.get(cache_key)
-        if response is None:
-            response = HttpResponse(file.read_text(), content_type="text/javascript")
-            _web_module_cache.set(cache_key, response, timeout=None)
-
-        return response
+async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
+    """Gets a web modules file. Web modules files  from cache"""
+    path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
+    last_modified_time = os.stat(path).st_mtime
+    cache_key = f"django_idom:{path}"
+    response = idom_cache.get(cache_key, version=last_modified_time)
+    if response is None:
+        response = HttpResponse(path.read_text(), content_type="text/javascript")
+        idom_cache.set(cache_key, response, timeout=None, version=last_modified_time)
+    return response

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -14,13 +14,13 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     web_modules_dir = IDOM_WED_MODULES_DIR.current
     path = web_modules_dir.joinpath(*file.split("/")).absolute()
 
-    # Check for attempts to walk outside of the web modules dir
+    # Prevent attempts to walk outside of the web modules dir
     if str(web_modules_dir) != os.path.commonpath((path, web_modules_dir)):
         raise SuspiciousOperation(
             "Attempt to access a directory outside of IDOM_WED_MODULES_DIR."
         )
 
-    # Fetch the web modules file from cache, if available
+    # Fetch the file from cache, if available
     last_modified_time = os.stat(path).st_mtime
     cache_key = f"django_idom:web_module:{str(path).lstrip(str(web_modules_dir))}"
     response = await IDOM_CACHE.aget(cache_key, version=last_modified_time)

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -18,5 +18,6 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     response = idom_cache.get(cache_key, version=last_modified_time)
     if response is None:
         response = HttpResponse(path.read_text(), content_type="text/javascript")
+        idom_cache.delete(cache_key)
         idom_cache.set(cache_key, response, timeout=None, version=last_modified_time)
     return response

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -12,7 +12,8 @@ idom_cache = caches[IDOM_CACHE]
 
 
 async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
-    """Gets a web modules file. Web modules files  from cache"""
+    """Gets JavaScript required for IDOM modules at runtime. These modules are
+    returned from cache if available."""
     path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
     last_modified_time = os.stat(path).st_mtime
     cache_key = f"django_idom:web_module:{path}"

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -21,7 +21,6 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     if response is None:
         async with async_open(path, "r") as fp:
             response = HttpResponse(await fp.read(), content_type="text/javascript")
-        await idom_cache.adelete(cache_key)
         await idom_cache.aset(
             cache_key, response, timeout=None, version=last_modified_time
         )

--- a/src/django_idom/views.py
+++ b/src/django_idom/views.py
@@ -1,5 +1,6 @@
 import os
 
+from aiofile import async_open
 from django.core.cache import caches
 from django.http import HttpRequest, HttpResponse
 from idom.config import IDOM_WED_MODULES_DIR
@@ -14,10 +15,11 @@ async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
     """Gets a web modules file. Web modules files  from cache"""
     path = IDOM_WED_MODULES_DIR.current.joinpath(*file.split("/")).absolute()
     last_modified_time = os.stat(path).st_mtime
-    cache_key = f"django_idom:{path}"
+    cache_key = f"django_idom:web_module:{path}"
     response = await idom_cache.aget(cache_key, version=last_modified_time)
     if response is None:
-        response = HttpResponse(path.read_text(), content_type="text/javascript")
+        async with async_open(path, "r") as fp:
+            response = HttpResponse(await fp.read(), content_type="text/javascript")
         await idom_cache.adelete(cache_key)
         await idom_cache.aset(
             cache_key, response, timeout=None, version=last_modified_time


### PR DESCRIPTION
- [Use Django async caching API](https://docs.djangoproject.com/en/4.0/topics/cache/#asynchronous-support)
   - Note: This limits us to Django 4.0+, Python 3.8+.
- Remove async_lru_cache.
   - [Django's default cache engine is functionally equivalent](https://docs.djangoproject.com/en/4.0/topics/cache/#local-memory-caching).
- Fix #46 
- Use [`aiofile`](https://github.com/mosquito/aiofile) for async file operations.
- Protect against malicious file paths (ex `../../../etc/passwd`)
- [Use cache versioning to invalidate old web module files stored in cache](https://docs.djangoproject.com/en/4.0/topics/cache/#cache-versioning)