### PR TITLE
Fix 0.0.3 Publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Types of changes are to be listed in this order
 
 ## [Unreleased]
 
+- Nothing (yet)
+
+## [0.0.3] - 2022-02-19
+
 ### Changed
 
 - Bumped the minimum IDOM client version to 0.36.3

--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -1,14 +1,14 @@
 {
   "name": "django-idom-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "django-idom-client",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
-        "idom-client-react": "^0.36.0",
+        "idom-client-react": "^0.36.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2"
       },
@@ -102,9 +102,9 @@
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "node_modules/idom-client-react": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/idom-client-react/-/idom-client-react-0.36.0.tgz",
-      "integrity": "sha512-mK/bvsPOLOMxgiItZxSbREMSKne7s244UHuvr0lD1IJ1uSEg9jpgz2YzkX4oPgOVd3j6MydJ/6XmEObsoYq3pQ==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/idom-client-react/-/idom-client-react-0.36.3.tgz",
+      "integrity": "sha512-nWMy1cSwPe6N9k1EHendLPtLXH3n7JCfwSfApQEtbq4ngseHLlIG2inSLP68MqDcd9HwV8y0837QF0C4dhqwvw==",
       "dependencies": {
         "fast-json-patch": "^3.0.0-1",
         "htm": "^3.0.3"
@@ -382,9 +382,9 @@
       "integrity": "sha512-L0s3Sid5r6YwrEvkig14SK3Emmc+kIjlfLhEGn2Vy3bk21JyDEes4MoDsbJk6luaPp8bugErnxPz86ZuAw6e5Q=="
     },
     "idom-client-react": {
-      "version": "0.36.0",
-      "resolved": "https://registry.npmjs.org/idom-client-react/-/idom-client-react-0.36.0.tgz",
-      "integrity": "sha512-mK/bvsPOLOMxgiItZxSbREMSKne7s244UHuvr0lD1IJ1uSEg9jpgz2YzkX4oPgOVd3j6MydJ/6XmEObsoYq3pQ==",
+      "version": "0.36.3",
+      "resolved": "https://registry.npmjs.org/idom-client-react/-/idom-client-react-0.36.3.tgz",
+      "integrity": "sha512-nWMy1cSwPe6N9k1EHendLPtLXH3n7JCfwSfApQEtbq4ngseHLlIG2inSLP68MqDcd9HwV8y0837QF0C4dhqwvw==",
       "requires": {
         "fast-json-patch": "^3.0.0-1",
         "htm": "^3.0.3"

--- a/src/js/package.json
+++ b/src/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "django-idom-client",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "test app for idom_django websocket server",
   "main": "src/index.js",
   "files": [


### PR DESCRIPTION
We forgot to bump `django-idom-client`.

We should think of some way of automating this, even if it's just a simple python script that manually edits all these values through regex.