### PR TITLE
Remove misc script from django_css

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Types of changes are to be listed in this order
 
 -   Nothing (yet)
 
-## [1.1.0] - 2022-06-25
+## [1.1.0] - 2022-07-01
 
 ### Added
 

--- a/src/django_idom/components.py
+++ b/src/django_idom/components.py
@@ -14,16 +14,7 @@ def django_css(static_path: str):
         static_path: The path to the static file. This path is identical to what you would
         use on a `static` template tag.
     """
-    return html._(
-        html.script(
-            """
-            let parentTag = document.currentScript;
-            console.log(parentTag);
-            //parentTag.attachShadow({ mode: 'open' });
-            """
-        ),
-        html.style(_cached_static_contents(static_path)),
-    )
+    return html._(html.style(_cached_static_contents(static_path)))
 
 
 @component


### PR DESCRIPTION
I accidentally commited a script I was using to test ShadowDOM when incorporating the review on PR #78.