### PR TITLE
use_sync_to_async Hook

### DIFF
--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -1,8 +1,38 @@
-# Django Hooks
-
 ???+ tip "Looking for more hooks?"
 
     Check out the [IDOM Core docs](https://idom-docs.herokuapp.com/docs/reference/hooks-api.html?highlight=hooks) on hooks!
+
+## Use Sync to Async
+
+This is the suggested method of performing ORM queries when using Django IDOM.
+
+```python title="components.py"
+from example_project.my_app.models import Category
+from channels.db import database_sync_to_async
+from idom import component, html
+from django_idom import hooks
+
+@component
+def simple_list():
+    categories, set_categories = hooks.use_state(None)
+
+    @hooks.use_sync_to_async
+    def get_categories():
+        if categories:
+            return
+        set_categories(Category.objects.all())
+
+    if not categories:
+        return html.h2("Loading...")
+
+    return html.ul(
+        [html.li(category.name, key=category.name) for category in categories]
+    )
+```
+
+??? question "Why can't I make ORM calls without hooks?"
+
+    Due to Django's ORM design, database queries must be deferred using hooks. Otherwise, you will see a `SynchronousOnlyOperation` exception.
 
 ## Use Websocket
 
@@ -18,8 +48,6 @@ def MyComponent():
     return html.div(my_websocket)
 ```
 
-
-
 ## Use Scope
 
 This is a shortcut that returns the Websocket's `scope`.
@@ -33,7 +61,6 @@ def MyComponent():
     my_scope = use_scope()
     return html.div(my_scope)
 ```
-
 
 ## Use Location
 

--- a/docs/features/hooks.md
+++ b/docs/features/hooks.md
@@ -4,7 +4,9 @@
 
 ## Use Sync to Async
 
-This is the suggested method of performing ORM queries when using Django IDOM.
+This is the suggested method of performing ORM queries when using Django IDOM. 
+
+Fundamentally, this hook is an ORM-safe version of [use_effect](https://idom-docs.herokuapp.com/docs/reference/hooks-api.html#use-effect).
 
 ```python title="components.py"
 from example_project.my_app.models import Category

--- a/src/django_idom/hooks.py
+++ b/src/django_idom/hooks.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
+from inspect import iscoroutinefunction
 from typing import (
+    TYPE_CHECKING,
     Any,
     Awaitable,
     Callable,
@@ -11,6 +13,7 @@ from typing import (
     overload,
 )
 
+from channels.db import database_sync_to_async
 from idom.backend.types import Location
 from idom.core.hooks import (
     Context,
@@ -19,8 +22,12 @@ from idom.core.hooks import (
     use_context,
     use_effect,
 )
-from channels.db import database_sync_to_async
-from inspect import iscoroutinefunction
+
+
+if not TYPE_CHECKING:
+    # make flake8 think that this variable exists
+    ellipsis = type(...)
+
 
 @dataclass
 class IdomWebsocket:

--- a/src/django_idom/hooks.py
+++ b/src/django_idom/hooks.py
@@ -66,7 +66,7 @@ def use_websocket() -> IdomWebsocket:
 @overload
 def use_sync_to_async(
     function: None = None,
-    dependencies: Sequence[Any] | ellipsis | None = ...,
+    dependencies: Union[Sequence[Any], ellipsis, None] = ...,
 ) -> Callable[[_EffectApplyFunc], None]:
     ...
 
@@ -74,14 +74,14 @@ def use_sync_to_async(
 @overload
 def use_sync_to_async(
     function: _EffectApplyFunc,
-    dependencies: Sequence[Any] | ellipsis | None = ...,
+    dependencies: Union[Sequence[Any], ellipsis, None] = ...,
 ) -> None:
     ...
 
 
 def use_sync_to_async(
     function: Optional[_EffectApplyFunc] = None,
-    dependencies: Sequence[Any] | ellipsis | None = ...,
+    dependencies: Union[Sequence[Any], ellipsis, None] = ...,
 ) -> Optional[Callable[[_EffectApplyFunc], None]]:
     """This is a sync_to_async wrapper for `idom.hooks.use_effect`.
     See the full :ref:`Use Effect` docs for details


### PR DESCRIPTION
This hook is best way I can think of developing ORM query support, at least in a way that Django developers would understand.

Potentially closes the following
- #79
- #80