### PR TITLE
Allow whitespace characters within component regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ Using the following categories, list your changes in this order:
 
 ### Fixed
 
--   IDOM template tag parser is no longer sensitive to whitespace.
+-   IDOM preloader is no longer sensitive to whitespace within template tags.
 
 ## [1.1.0] - 2022-07-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,10 @@ Using the following categories, list your changes in this order:
 -   `use_query` hook for fetching database values.
 -   `use_mutation` hook for modifying database values.
 
+### Fixed
+
+-   IDOM template tag parser is no longer sensitive to whitespace.
+
 ## [1.1.0] - 2022-07-01
 
 ### Added

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -13,7 +13,9 @@ from django.utils.encoding import smart_str
 from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
 
-COMPONENT_REGEX = re.compile(r"{% *component +((\"[^\"']*\")|('[^\"']*'))(.*?)%}")
+COMPONENT_REGEX = re.compile(
+    r"{%\s*component\s*((\"[^\"']*\")|('[^\"']*'))\s*((.*?|\s*?)*)\s*%}"
+)
 _logger = logging.getLogger(__name__)
 
 

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -13,6 +13,7 @@ from django.utils.encoding import smart_str
 from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
 
+_logger = logging.getLogger(__name__)
 _component_tag = r"component"
 _component_path = r"((\"[^\"']*\")|('[^\"']*'))"
 _component_kwargs = r"((.*?|\s*?)*)"
@@ -25,7 +26,6 @@ COMPONENT_REGEX = re.compile(
     + _component_kwargs
     + r"\s*%}"
 )
-_logger = logging.getLogger(__name__)
 
 
 def _register_component(full_component_name: str) -> None:

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -114,14 +114,11 @@ class ComponentPreloader:
             with contextlib.suppress(Exception):
                 with open(template, "r", encoding="utf-8") as template_file:
                     regex_iterable = COMPONENT_REGEX.finditer(template_file.read())
-                    if not regex_iterable:
-                        continue
-                    components.update(
-                        [
-                            match.groupdict()["path"].replace('"', "").replace("'", "")
-                            for match in regex_iterable
-                        ]
-                    )
+                    component_paths = [
+                        match.group("path").replace('"', "").replace("'", "")
+                        for match in regex_iterable
+                    ]
+                    components.update(component_paths)
         if not components:
             _logger.warning(
                 "\033[93m"

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -13,8 +13,17 @@ from django.utils.encoding import smart_str
 from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
 
+_component_tag = r"component"
+_component_path = r"((\"[^\"']*\")|('[^\"']*'))"
+_component_kwargs = r"((.*?|\s*?)*)"
 COMPONENT_REGEX = re.compile(
-    r"{%\s*component\s*((\"[^\"']*\")|('[^\"']*'))\s*((.*?|\s*?)*)\s*%}"
+    r"{%\s*"
+    + _component_tag
+    + r"\s*"
+    + _component_path
+    + r"\s*"
+    + _component_kwargs
+    + r"\s*%}"
 )
 _logger = logging.getLogger(__name__)
 

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -14,7 +14,7 @@ from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
 
 _logger = logging.getLogger(__name__)
-_component_tag = r"component"
+_component_tag = r"(?P<tag>component)"
 _component_path = r"(?P<path>(\"[^\"'\s]*\")|('[^\"'\s]*'))"
 _component_kwargs = r"(?P<kwargs>(.*?|\s*?)*)"
 COMPONENT_REGEX = re.compile(

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -15,7 +15,7 @@ from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
 _logger = logging.getLogger(__name__)
 _component_tag = r"(?P<tag>component)"
-_component_path = r"(?P<path>(\"[^\"'\s]*\")|('[^\"'\s]*'))"
+_component_path = r"(?P<path>(\"[^\"'\s]+\")|('[^\"'\s]+'))"
 _component_kwargs = r"(?P<kwargs>(.*?|\s*?)*)"
 COMPONENT_REGEX = re.compile(
     r"{%\s*"

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -13,6 +13,14 @@ class RegexTests(TestCase):
             r"{% component 'my.component' %}",
             r'{% component "my.component" class="my_thing" %}',
             r'{% component "my.component" class="my_thing" attr="attribute" %}',
+            r"""{%
+
+                component   
+                "my.component"  
+                class="my_thing"  
+                attr="attribute"  
+
+            %}""",  # noqa: W291
         }:
             self.assertRegex(component, COMPONENT_REGEX)
 

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -37,5 +37,7 @@ class RegexTests(TestCase):
             r'{% component " my.component " %}',
             r"""{% component "my.component
                         " %}""",
+            r'{{ component """ }}',
+            r'{{ component "" }}',
         }:
             self.assertNotRegex(fake_component, COMPONENT_REGEX)

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -34,5 +34,8 @@ class RegexTests(TestCase):
             r"{%%}",
             r" ",
             r"",
+            r'{% component " my.component " %}',
+            r"""{% component "my.component
+                        " %}""",
         }:
             self.assertNotRegex(fake_component, COMPONENT_REGEX)


### PR DESCRIPTION
## Description

I realized some handlebars formatters will add indentation and newlines. Therefore, I've made the component regex a bit more robust to handle those situations.

## Checklist:

Please update this checklist as you complete each item:

-   [X] Tests have been included for all bug fixes or added functionality.
-   [x] The `changelog.rst` has been updated with any significant changes, if necessary.
-   [X] GitHub Issues which may be closed by this PR have been linked.
