### PR TITLE
Fix IDOM preloader trying to parse commented out HTML templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Using the following categories, list your changes in this order:
 -   `use_query` will now prefetch all fields to prevent `SynchronousOnlyOperation` exceptions.
 -   `view_to_component`, `django_css`, and `django_js` type hints will now display like normal functions.
 -   IDOM preloader no longer attempts to parse commented out IDOM components.
+-   Tests are now fully functional on Windows
 
 ## [1.2.0] - 2022-09-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Using the following categories, list your changes in this order:
 -   Allow `use_mutation` to have `refetch=None`, as the docs suggest is possible.
 -   `use_query` will now prefetch all fields to prevent `SynchronousOnlyOperation` exceptions.
 -   `view_to_component`, `django_css`, and `django_js` type hints will now display like normal functions.
+-   IDOM preloader no longer attempts to parse commented out IDOM components.
 
 ## [1.2.0] - 2022-09-19
 

--- a/requirements/test-env.txt
+++ b/requirements/test-env.txt
@@ -1,3 +1,4 @@
 django
 playwright
 twisted
+daphne

--- a/requirements/test-env.txt
+++ b/requirements/test-env.txt
@@ -1,4 +1,4 @@
 django
 playwright
 twisted
-daphne
+channels[daphne]>=4.0.0

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -18,6 +18,7 @@ _logger = logging.getLogger(__name__)
 _component_tag = r"(?P<tag>component)"
 _component_path = r"(?P<path>(\"[^\"'\s]+\")|('[^\"'\s]+'))"
 _component_kwargs = r"(?P<kwargs>(.*?|\s*?)*)"
+COMMENT_REGEX = re.compile(r"(<!--)(.|\s)*?(-->)")
 COMPONENT_REGEX = re.compile(
     r"{%\s*"
     + _component_tag
@@ -112,7 +113,8 @@ class ComponentPreloader:
         for template in templates:
             with contextlib.suppress(Exception):
                 with open(template, "r", encoding="utf-8") as template_file:
-                    regex_iterable = COMPONENT_REGEX.finditer(template_file.read())
+                    clean_template = COMMENT_REGEX.sub("", template_file.read())
+                    regex_iterable = COMPONENT_REGEX.finditer(clean_template)
                     component_paths = [
                         match.group("path").replace('"', "").replace("'", "")
                         for match in regex_iterable

--- a/tests/test_app/tests/test_components.py
+++ b/tests/test_app/tests/test_components.py
@@ -1,6 +1,6 @@
+import asyncio
 import os
 import sys
-from unittest import SkipTest
 
 from channels.testing import ChannelsLiveServerTestCase
 from playwright.sync_api import TimeoutError, sync_playwright
@@ -13,13 +13,7 @@ class TestIdomCapabilities(ChannelsLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         if sys.platform == "win32":
-            raise SkipTest("These tests are broken on Windows.")
-
-            # FIXME: The following lines will be needed once Django channels fixes Windows tests
-            # See: https://github.com/django/channels/issues/1207
-
-            # import asyncio
-            # asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
+            asyncio.set_event_loop_policy(asyncio.WindowsProactorEventLoopPolicy())
 
         # FIXME: This is required otherwise the tests will throw a `SynchronousOnlyOperation`
         # error when deleting the test datatabase. Potentially a Django bug.

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -43,12 +43,27 @@ class RegexTests(TestCase):
             self.assertNotRegex(fake_component, COMPONENT_REGEX)
 
     def test_comment_regex(self):
-        for comment in {r"<!-- comment -->"}:
+        for comment in {
+            r"<!-- comment -->",
+            r"""<!-- comment
+            -->""",
+            r"""<!--
+             comment -->""",
+            r"""<!--
+            comment
+            -->""",
+            r"""<!-- 
+            a comment
+            another comments
+            drink some cement 
+            -->""",  # noqa: W291
+        }:
             self.assertRegex(comment, COMMENT_REGEX)
 
         for fake_comment in {
             r"<!-- a comment ",
             r"another comment -->",
+            r"<! - - comment - - >",
             r'{% component "my.component" %}',
         }:
             self.assertNotRegex(fake_comment, COMMENT_REGEX)
@@ -57,12 +72,12 @@ class RegexTests(TestCase):
             r'{% component "my.component" %} <!-- comment -->',
             r'<!-- comment --> {% component "my.component" %}',
             r'<!-- comment --> {% component "my.component" %} <!-- comment -->',
-            r"""<!-- comment 
+            r"""<!-- comment
                     --> {% component "my.component" %}
                     <!-- comment -->
                 <!--
                 comment -->""",
-        }:
+        }:  # noqa: W291
             comment = COMMENT_REGEX.sub("", embedded_comment)
             if comment.strip() != '{% component "my.component" %}':
                 raise self.failureException(

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -78,8 +78,8 @@ class RegexTests(TestCase):
                 <!--
                 comment -->""",
         }:  # noqa: W291
-            comment = COMMENT_REGEX.sub("", embedded_comment)
-            if comment.strip() != '{% component "my.component" %}':
+            text = COMMENT_REGEX.sub("", embedded_comment)
+            if text.strip() != '{% component "my.component" %}':
                 raise self.failureException(
                     f"Regex pattern {COMMENT_REGEX.pattern} failed to remove comment from {embedded_comment}"
                 )

--- a/tests/test_app/tests/test_regex.py
+++ b/tests/test_app/tests/test_regex.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from django_idom.utils import COMPONENT_REGEX
+from django_idom.utils import COMMENT_REGEX, COMPONENT_REGEX
 
 
 class RegexTests(TestCase):
@@ -41,3 +41,30 @@ class RegexTests(TestCase):
             r'{{ component "" }}',
         }:
             self.assertNotRegex(fake_component, COMPONENT_REGEX)
+
+    def test_comment_regex(self):
+        for comment in {r"<!-- comment -->"}:
+            self.assertRegex(comment, COMMENT_REGEX)
+
+        for fake_comment in {
+            r"<!-- a comment ",
+            r"another comment -->",
+            r'{% component "my.component" %}',
+        }:
+            self.assertNotRegex(fake_comment, COMMENT_REGEX)
+
+        for embedded_comment in {
+            r'{% component "my.component" %} <!-- comment -->',
+            r'<!-- comment --> {% component "my.component" %}',
+            r'<!-- comment --> {% component "my.component" %} <!-- comment -->',
+            r"""<!-- comment 
+                    --> {% component "my.component" %}
+                    <!-- comment -->
+                <!--
+                comment -->""",
+        }:
+            comment = COMMENT_REGEX.sub("", embedded_comment)
+            if comment.strip() != '{% component "my.component" %}':
+                raise self.failureException(
+                    f"Regex pattern {COMMENT_REGEX.pattern} failed to remove comment from {embedded_comment}"
+                )


### PR DESCRIPTION
## Description

- fix #102
- fix #14 

## Checklist:

Please update this checklist as you complete each item:

-   [x] Tests have been included for all bug fixes or added functionality.
-   [x] The `changelog.rst` has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
