### PR TITLE
v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)
 
-## [2.1.0] - 2022-10-31
+## [2.1.0] - 2022-11-01
 
 ## Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)
 
-## [2.0.2] - 2022-10-19
+## [2.1.0] - 2022-10-27
 
 ## Changed
 
@@ -170,8 +170,8 @@ Using the following categories, list your changes in this order:
 
 -   Support for IDOM within the Django
 
-[unreleased]: https://github.com/idom-team/django-idom/compare/2.0.2...HEAD
-[2.0.2]: https://github.com/idom-team/django-idom/compare/2.0.1...2.0.2
+[unreleased]: https://github.com/idom-team/django-idom/compare/2.1.0...HEAD
+[2.0.2]: https://github.com/idom-team/django-idom/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/idom-team/django-idom/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/idom-team/django-idom/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/idom-team/django-idom/compare/1.1.0...1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,13 +24,28 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)
 
-## [2.0.1]- 2022-10-18
+## [2.0.2] - 2022-10-19
+
+## Changed
+
+-   Minimum `channels` version is now `4.0.0`.
 
 ### Fixed
 
--   Ability to use `key=...` parameter on all prefabricated components
+-   Change type hint on `view_to_component` callable to have `request` argument be optional.
+-   Have docs demonstrate how to use Django-IDOM with `channels>=4.0.0`.
 
-## [2.0.0]- 2022-10-17
+## Security
+
+-   Add note to docs about potential information exposure via `view_to_component` when using `compatibility=True`.
+
+## [2.0.1] - 2022-10-18
+
+### Fixed
+
+-   Ability to use `key=...` parameter on all prefabricated components.
+
+## [2.0.0] - 2022-10-17
 
 ### Added
 
@@ -155,7 +170,8 @@ Using the following categories, list your changes in this order:
 
 -   Support for IDOM within the Django
 
-[unreleased]: https://github.com/idom-team/django-idom/compare/2.0.1...HEAD
+[unreleased]: https://github.com/idom-team/django-idom/compare/2.0.2...HEAD
+[2.0.2]: https://github.com/idom-team/django-idom/compare/2.0.1...2.0.2
 [2.0.1]: https://github.com/idom-team/django-idom/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/idom-team/django-idom/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/idom-team/django-idom/compare/1.1.0...1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Using the following categories, list your changes in this order:
 
 -   Nothing (yet)
 
-## [2.1.0] - 2022-10-27
+## [2.1.0] - 2022-10-31
 
 ## Changed
 
@@ -171,7 +171,7 @@ Using the following categories, list your changes in this order:
 -   Support for IDOM within the Django
 
 [unreleased]: https://github.com/idom-team/django-idom/compare/2.1.0...HEAD
-[2.0.2]: https://github.com/idom-team/django-idom/compare/2.0.1...2.1.0
+[2.1.0]: https://github.com/idom-team/django-idom/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/idom-team/django-idom/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/idom-team/django-idom/compare/1.2.0...2.0.0
 [1.2.0]: https://github.com/idom-team/django-idom/compare/1.1.0...1.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Using the following categories, list your changes in this order:
 ### Fixed
 
 -   Change type hint on `view_to_component` callable to have `request` argument be optional.
--   Have docs demonstrate how to use Django-IDOM with `channels>=4.0.0`.
+-   Change type hint on `view_to_component` to represent it as a decorator with paranthesis (ex `@view_to_component(compatibility=True)`)
 
 ## Security
 

--- a/docs/src/contribute/running-tests.md
+++ b/docs/src/contribute/running-tests.md
@@ -1,15 +1,26 @@
-This repo uses [Nox](https://nox.thea.codes/en/stable/) to run scripts which can be found in `noxfile.py`. For a full test of available scripts run `nox -l`. To run the full test suite simple execute:
+This repo uses [Nox](https://nox.thea.codes/en/stable/) to run tests. For a full test of available scripts run `nox -l`.
+
+If you plan to run tests, you'll need to install the following dependencies first:
+
+-   [Python 3.8+](https://www.python.org/downloads/)
+-   [Git](https://git-scm.com/downloads)
+
+Once done, you should clone this repository:
+
+```bash
+git clone https://github.com/idom-team/django-idom.git
+cd django-idom
+pip install -r ./requirements/test-run.txt --upgrade
+```
+
+Then, by running the command below you can run the full test suite:
 
 ```
 nox -s test
 ```
 
-If you do not want to run the tests in the background:
+Or, if you want to run the tests in the foreground:
 
 ```
 nox -s test -- --headed
 ```
-
-!!! warning "Most tests will not run on Windows"
-
-    Due to [bugs within Django Channels](https://github.com/django/channels/issues/1207), functional tests are not run on Windows. In order for Windows users to test Django-IDOM functionality, you will need to run tests via [Windows Subsystem for Linux](https://code.visualstudio.com/docs/remote/wsl).

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -41,7 +41,13 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
     | --- | --- |
     | `_ViewComponentConstructor` | A function that takes `request: HttpRequest | None, *args: Any, key: Key | None, **kwargs: Any` and returns an IDOM component. |
 
-??? warning "Existing limitations"
+??? Warning "Potential information exposure when using `compatibility = True`"
+
+    When using `compatibility` mode, IDOM automatically exposes a URL to your view.
+
+    It is your responsibility to ensure priveledged information is not leaked via this method. This can be done via directly writing conditionals into your view, or by adding decorators such as [user_passes_test](https://docs.djangoproject.com/en/dev/topics/auth/default/#django.contrib.auth.decorators.user_passes_test) to your views prior to using `view_to_component`.
+
+??? info "Existing limitations"
 
     There are currently several limitations of using `view_to_component` that may be resolved in a future version of `django_idom`.
 
@@ -77,9 +83,9 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
 
 ??? question "How do I transform views from external libraries?"
 
-    === "components.py"
-
         In order to convert external views, you can utilize `view_to_component` as a function, rather than a decorator.
+
+    === "components.py"
 
         ```python linenums="1"
         from idom import component, html
@@ -87,16 +93,47 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
         from django_idom.components import view_to_component
         from some_library.views import example_view
 
-        converted_view = view_to_component(example_view)
+        example_vtc = view_to_component(example_view)
 
         @component
         def my_component():
             return html.div(
-                converted_view(),
+                example_vtc(),
             )
         ```
 
-??? question "How do I provide `args` and `kwargs` to a view?"
+??? question "How do I provide `request`, `args`, and `kwargs` to a view?"
+
+    <font size="4">**`Request`**</font>
+
+    You can use the `request` parameter to provide the view a custom request object.
+
+    === "components.py"
+
+        ```python linenums="1"
+        from idom import component, html
+        from django.http import HttpResponse, HttpRequest
+        from django_idom.components import view_to_component
+
+        example_request = HttpRequest()
+        example_request.method = "PUT"
+
+        @view_to_component
+        def hello_world_view(request):
+            return HttpResponse(f"Hello World! {request.method}")
+
+        @component
+        def my_component():
+            return html.div(
+                hello_world_view(
+                    example_request,
+                ),
+            )
+        ```
+
+    ---
+
+    <font size="4">**`args` and `kwargs`**</font>
 
     You can use the `args` and `kwargs` parameters to provide positional and keyworded arguments to a view.
 
@@ -124,34 +161,41 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
             )
         ```
 
-??? question "How do I provide a custom `request` object to a view?"
+??? question "How do I use `strict_parseing`, `compatibility`, and `transforms`?"
 
-    You can use the `request` parameter to provide the view a custom request object.
+    <font size="4">**`strict_parsing`**</font>
+
+    By default, an exception will be generated if your view's HTML does not perfectly adhere to HTML5.
+
+    However, there are some circumstances where you may not have control over the original HTML, so you may be unable to fix it. Or you may be relying on non-standard HTML tags such as `#!html <my-tag> Hello World </my-tag>`.
+
+    In these scenarios, you may want to rely on best-fit parsing by setting the `strict_parsing` parameter to `False`.
+
+    Note that best-fit parsing is designed to be similar to how web browsers would handle non-standard or broken HTML.
 
     === "components.py"
 
         ```python linenums="1"
         from idom import component, html
-        from django.http import HttpResponse, HttpRequest
+        from django.http import HttpResponse
         from django_idom.components import view_to_component
 
-        example_request = HttpRequest()
-        example_request.method = "PUT"
-
-        @view_to_component
+        @view_to_component(strict_parsing=False)
         def hello_world_view(request):
-            return HttpResponse(f"Hello World! {request.method}")
+            return HttpResponse("<my-tag> Hello World </my-tag>")
 
         @component
         def my_component():
             return html.div(
-                hello_world_view(
-                    example_request,
-                ),
+                hello_world_view(),
             )
         ```
 
-??? question "What is `compatibility` mode?"
+
+
+    ---
+
+    <font size="4">**`compatibility`**</font>
 
     For views that rely on HTTP responses other than `GET` (such as `PUT`, `POST`, `PATCH`, etc), you should consider using compatibility mode to render your view within an iframe.
 
@@ -177,35 +221,9 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
             )
         ```
 
-??? question "What is `strict_parsing`?"
+    ---
 
-    By default, an exception will be generated if your view's HTML does not perfectly adhere to HTML5.
-
-    However, there are some circumstances where you may not have control over the original HTML, so you may be unable to fix it. Or you may be relying on non-standard HTML tags such as `#!html <my-tag> Hello World </my-tag>`.
-
-    In these scenarios, you may want to rely on best-fit parsing by setting the `strict_parsing` parameter to `False`.
-
-    === "components.py"
-
-        ```python linenums="1"
-        from idom import component, html
-        from django.http import HttpResponse
-        from django_idom.components import view_to_component
-
-        @view_to_component(strict_parsing=False)
-        def hello_world_view(request):
-            return HttpResponse("<my-tag> Hello World </my-tag>")
-
-        @component
-        def my_component():
-            return html.div(
-                hello_world_view(),
-            )
-        ```
-
-    Note that best-fit parsing is very similar to how web browsers will handle broken HTML.
-
-??? question "What is `transforms`?"
+    <font size="4">**`transforms`**</font>
 
     After your view has been turned into [VDOM](https://idom-docs.herokuapp.com/docs/reference/specifications.html#vdom) (python dictionaries), `view_to_component` will call your `transforms` functions on every VDOM node.
 

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -4,7 +4,7 @@
 
 ## View To Component
 
-Convert any Django view into a IDOM component by usng this decorator. Compatible with sync/async [Function Based Views](https://docs.djangoproject.com/en/dev/topics/http/views/) and [Class Based Views](https://docs.djangoproject.com/en/dev/topics/class-based-views/).
+Convert any Django view into a IDOM component by usng this decorator. Compatible with [Function Based Views](https://docs.djangoproject.com/en/dev/topics/http/views/) and [Class Based Views](https://docs.djangoproject.com/en/dev/topics/class-based-views/). Views can be sync or async.
 
 === "components.py"
 

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -108,7 +108,7 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
 
 ??? question "How do I transform views from external libraries?"
 
-        In order to convert external views, you can utilize `view_to_component` as a function, rather than a decorator.
+    In order to convert external views, you can utilize `view_to_component` as a function, rather than a decorator.
 
     === "components.py"
 

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -45,7 +45,31 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
 
     When using `compatibility` mode, IDOM automatically exposes a URL to your view.
 
-    It is your responsibility to ensure priveledged information is not leaked via this method. This can be done via directly writing conditionals into your view, or by adding decorators such as [user_passes_test](https://docs.djangoproject.com/en/dev/topics/auth/default/#django.contrib.auth.decorators.user_passes_test) to your views prior to using `view_to_component`.
+    It is your responsibility to ensure priveledged information is not leaked via this method.
+
+    This can be done via directly writing conditionals into your view, or by adding decorators such as [user_passes_test](https://docs.djangoproject.com/en/dev/topics/auth/default/#django.contrib.auth.decorators.user_passes_test) to your views prior to using `view_to_component`.
+
+    === "Function Based View"
+
+        ```python
+        ...
+
+        @view_to_component(compatibility=True)
+        @user_passes_test(lambda u: u.is_superuser)
+        def example_view(request):
+            ...
+        ```
+
+    === "Class Based View"
+
+        ```python
+        ...
+
+        @view_to_component(compatibility=True)
+        @method_decorator(user_passes_test(lambda u: u.is_superuser), name="dispatch")
+        class ExampleView(TemplateView):
+            ...
+        ```
 
 ??? info "Existing limitations"
 

--- a/docs/src/features/components.md
+++ b/docs/src/features/components.md
@@ -52,6 +52,7 @@ Convert any Django view into a IDOM component by usng this decorator. Compatible
     There are currently several limitations of using `view_to_component` that may be resolved in a future version of `django_idom`.
 
     - Requires manual intervention to change request methods beyond `GET`.
+    - IDOM events cannot conveniently be attached to converted view HTML.
     - Does not currently load any HTML contained with a `<head>` tag
     - Has no option to automatically intercept local anchor link (ex. `#!html <a href='example/'></a>`) click events
 

--- a/docs/src/features/hooks.md
+++ b/docs/src/features/hooks.md
@@ -324,12 +324,6 @@ You can expect this hook to provide strings such as `/idom/my_path`.
         return html.div(my_location)
     ```
 
-??? info "This hook's behavior will be changed in a future update"
-
-    This hook will be updated to return the browser's currently active path. This change will come in alongside IDOM URL routing support.
-
-    Check out [idom-team/idom-router#2](https://github.com/idom-team/idom-router/issues/2) for more information.
-
 ??? example "See Interface"
 
     <font size="4">**Parameters**</font>
@@ -341,6 +335,12 @@ You can expect this hook to provide strings such as `/idom/my_path`.
     | Type | Description |
     | --- | --- |
     | `Location` | A object containing the current URL's `pathname` and `search` query. |
+
+??? info "This hook's behavior will be changed in a future update"
+
+    This hook will be updated to return the browser's currently active path. This change will come in alongside IDOM URL routing support.
+
+    Check out [idom-team/idom-router#2](https://github.com/idom-team/idom-router/issues/2) for more information.
 
 ## Use Origin
 

--- a/docs/src/getting-started/learn-more.md
+++ b/docs/src/getting-started/learn-more.md
@@ -8,4 +8,4 @@ Additionally, the vast majority of tutorials/guides you find for React can be ap
 
 | Learn More |
 | --- |
-| [Django-IDOM Advanced Usage](../features/components.md){ .md-button } [IDOM Hooks, Events, and More](https://idom-docs.herokuapp.com/docs/guides/creating-interfaces/index.html){ .md-button } [Ask Questions on GitHub Discussions](https://github.com/idom-team/idom/discussions){ .md-button .md-button--primary } |
+| [Django-IDOM Advanced Usage](../features/components.md){ .md-button } [IDOM Core Documentation](https://idom-docs.herokuapp.com/docs/guides/creating-interfaces/index.html){ .md-button } [Ask Questions on GitHub Discussions](https://github.com/idom-team/idom/discussions){ .md-button .md-button--primary } |

--- a/docs/src/installation/index.md
+++ b/docs/src/installation/index.md
@@ -29,7 +29,7 @@ In your settings you'll need to add `django_idom` to [`INSTALLED_APPS`](https://
 
     Django-IDOM requires ASGI in order to use Websockets.
 
-    If you haven't enabled ASGI on your **Django project** yet, you'll need to add `channels` to `INSTALLED_APPS` and set your `ASGI_APPLICATION` variable.
+    If you haven't enabled ASGI on your **Django project** yet, you'll need to install `channels[daphne]`, add `daphne` to `INSTALLED_APPS`, then set your `ASGI_APPLICATION` variable.
 
     Read the [Django Channels Docs](https://channels.readthedocs.io/en/stable/installation.html) for more info.
 
@@ -37,7 +37,7 @@ In your settings you'll need to add `django_idom` to [`INSTALLED_APPS`](https://
 
         ```python linenums="1"
         INSTALLED_APPS = [
-            "channels",
+            "daphne",
             ...
         ]
         ASGI_APPLICATION = "example_project.asgi.application"

--- a/noxfile.py
+++ b/noxfile.py
@@ -64,6 +64,7 @@ def test_types(session: Session) -> None:
     install_requirements_file(session, "check-types")
     install_requirements_file(session, "pkg-deps")
     session.run("mypy", "--show-error-codes", "src/django_idom")
+    session.run("mypy", "--show-error-codes", "tests/test_app")
 
 
 @nox.session

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,3 +16,4 @@ ignore_missing_imports = true
 warn_unused_configs = true
 warn_redundant_casts = true
 warn_unused_ignores = true
+check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,5 @@ lines_after_imports = 2
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_redundant_casts = true
-warn_unused_ignores = false
+warn_unused_ignores = true
 check_untyped_defs = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,5 +15,5 @@ lines_after_imports = 2
 ignore_missing_imports = true
 warn_unused_configs = true
 warn_redundant_casts = true
-warn_unused_ignores = true
+warn_unused_ignores = false
 check_untyped_defs = true

--- a/requirements/check-types.txt
+++ b/requirements/check-types.txt
@@ -1,2 +1,1 @@
 mypy
-django-stubs[compatible-mypy]

--- a/requirements/check-types.txt
+++ b/requirements/check-types.txt
@@ -1,1 +1,2 @@
 mypy
+django-stubs[compatible-mypy]

--- a/requirements/pkg-deps.txt
+++ b/requirements/pkg-deps.txt
@@ -1,4 +1,4 @@
-channels >=3.0.0
+channels >=4.0.0
 idom >=0.40.2, <0.41.0
 aiofile >=3.0
 typing_extensions

--- a/src/django_idom/__init__.py
+++ b/src/django_idom/__init__.py
@@ -3,7 +3,7 @@ from django_idom.types import IdomWebsocket
 from django_idom.websocket.paths import IDOM_WEBSOCKET_PATH
 
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"
 __all__ = [
     "IDOM_WEBSOCKET_PATH",
     "IdomWebsocket",

--- a/src/django_idom/__init__.py
+++ b/src/django_idom/__init__.py
@@ -3,7 +3,7 @@ from django_idom.types import IdomWebsocket
 from django_idom.websocket.paths import IDOM_WEBSOCKET_PATH
 
 
-__version__ = "2.0.1"
+__version__ = "2.0.2"
 __all__ = [
     "IDOM_WEBSOCKET_PATH",
     "IdomWebsocket",

--- a/src/django_idom/components.py
+++ b/src/django_idom/components.py
@@ -20,7 +20,7 @@ from django_idom.utils import _generate_obj_name
 
 class _ViewComponentConstructor(Protocol):
     def __call__(
-        self, request: HttpRequest | None, *args: Any, **kwargs: Any
+        self, request: HttpRequest | None = None, *args: Any, **kwargs: Any
     ) -> ComponentType:
         ...
 

--- a/src/django_idom/components.py
+++ b/src/django_idom/components.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import os
 from inspect import iscoroutinefunction
-from typing import Any, Callable, Protocol, Sequence
+from typing import Any, Callable, Protocol, Sequence, overload
 
 from channels.db import database_sync_to_async
 from django.contrib.staticfiles.finders import find
@@ -112,14 +112,37 @@ def _view_to_component(
     return converted_view
 
 
-# TODO: Might want to intercept href clicks and form submit events.
-# Form events will probably be accomplished through the upcoming DjangoForm.
+# Function definition of using view_to_component as a argless decorator,
+# or as a plain function call
+@overload
 def view_to_component(
-    view: Callable | View = None,  # type: ignore[assignment]
+    view: Callable | View,
     compatibility: bool = False,
     transforms: Sequence[Callable[[VdomDict], Any]] = (),
     strict_parsing: bool = True,
 ) -> _ViewComponentConstructor:
+    ...
+
+
+# Function definition when used as decorator with paranthesis arguments
+@overload
+def view_to_component(
+    view: None = ...,
+    compatibility: bool = False,
+    transforms: Sequence[Callable[[VdomDict], Any]] = (),
+    strict_parsing: bool = True,
+) -> Callable[[Callable], _ViewComponentConstructor]:
+    ...
+
+
+# TODO: Might want to intercept href clicks and form submit events.
+# Form events will probably be accomplished through the upcoming DjangoForm.
+def view_to_component(
+    view: Callable | View | None = None,
+    compatibility: bool = False,
+    transforms: Sequence[Callable[[VdomDict], Any]] = (),
+    strict_parsing: bool = True,
+) -> _ViewComponentConstructor | Callable[[Callable], _ViewComponentConstructor]:
     """Converts a Django view to an IDOM component.
 
     Keyword Args:

--- a/src/django_idom/components.py
+++ b/src/django_idom/components.py
@@ -112,8 +112,9 @@ def _view_to_component(
     return converted_view
 
 
-# Function definition of using view_to_component as a argless decorator,
-# or as a plain function call
+# Type hints for:
+#   example = view_to_component(my_view, ...)
+#   @view_to_component
 @overload
 def view_to_component(
     view: Callable | View,
@@ -124,7 +125,8 @@ def view_to_component(
     ...
 
 
-# Function definition when used as decorator with paranthesis arguments
+# Type hints for:
+#   @view_to_component(...)
 @overload
 def view_to_component(
     view: None = ...,

--- a/src/django_idom/components.py
+++ b/src/django_idom/components.py
@@ -76,7 +76,7 @@ def _view_to_component(
             return
 
         # Render Check 2: Async function view
-        elif iscoroutinefunction(view):
+        elif iscoroutinefunction(view) and callable(view):
             view_html = await view(request_obj, *_args, **_kwargs)
 
         # Render Check 3: Async class view

--- a/src/django_idom/decorators.py
+++ b/src/django_idom/decorators.py
@@ -11,7 +11,7 @@ from django_idom.hooks import use_websocket
 def auth_required(
     component: Callable | None = None,
     auth_attribute: str = "is_active",
-    fallback: ComponentType | VdomDict | None = None,
+    fallback: ComponentType | Callable | VdomDict | None = None,
 ) -> Callable:
     """If the user passes authentication criteria, the decorated component will be rendered.
     Otherwise, the fallback component will be rendered.

--- a/src/django_idom/http/views.py
+++ b/src/django_idom/http/views.py
@@ -1,13 +1,12 @@
 import os
-from inspect import iscoroutinefunction
 
 from aiofile import async_open
-from channels.db import database_sync_to_async
 from django.core.exceptions import SuspiciousOperation
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, HttpResponseNotFound
 from idom.config import IDOM_WED_MODULES_DIR
 
 from django_idom.config import IDOM_CACHE, IDOM_VIEW_COMPONENT_IFRAMES
+from django_idom.utils import render_view
 
 
 async def web_modules_file(request: HttpRequest, file: str) -> HttpResponse:
@@ -44,27 +43,10 @@ async def view_to_component_iframe(
     # Get the view from IDOM_REGISTERED_IFRAMES
     iframe = IDOM_VIEW_COMPONENT_IFRAMES.get(view_path)
     if not iframe:
-        raise ValueError(f"No view registered for component {view_path}.")
+        return HttpResponseNotFound()
 
-    # Render Check 1: Async function view
-    if iscoroutinefunction(iframe.view) and callable(iframe.view):
-        response = await iframe.view(request, *iframe.args, **iframe.kwargs)
-
-    # Render Check 2: Async class view
-    elif getattr(iframe.view, "view_is_async", False):
-        response = await iframe.view.as_view()(request, *iframe.args, **iframe.kwargs)  # type: ignore[misc, union-attr]
-
-    # Render Check 3: Sync class view
-    elif getattr(iframe.view, "as_view", None):
-        response = await database_sync_to_async(iframe.view.as_view())(  # type: ignore[union-attr]
-            request, *iframe.args, **iframe.kwargs
-        )
-
-    # Render Check 4: Sync function view
-    else:
-        response = await database_sync_to_async(iframe.view)(
-            request, *iframe.args, **iframe.kwargs
-        )
+    # Render the view
+    response = await render_view(iframe.view, request, iframe.args, iframe.kwargs)
 
     # Ensure page can be rendered as an iframe
     response["X-Frame-Options"] = "SAMEORIGIN"

--- a/src/django_idom/http/views.py
+++ b/src/django_idom/http/views.py
@@ -48,7 +48,7 @@ async def view_to_component_iframe(
 
     # Render Check 1: Async function view
     if iscoroutinefunction(iframe.view):
-        response = await iframe.view(request, *iframe.args, **iframe.kwargs)  # type: ignore[operator]
+        response = await iframe.view(request, *iframe.args, **iframe.kwargs)
 
     # Render Check 2: Async class view
     elif getattr(iframe.view, "view_is_async", False):

--- a/src/django_idom/http/views.py
+++ b/src/django_idom/http/views.py
@@ -47,7 +47,7 @@ async def view_to_component_iframe(
         raise ValueError(f"No view registered for component {view_path}.")
 
     # Render Check 1: Async function view
-    if iscoroutinefunction(iframe.view):
+    if iscoroutinefunction(iframe.view) and callable(iframe.view):
         response = await iframe.view(request, *iframe.args, **iframe.kwargs)
 
     # Render Check 2: Async class view

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -70,7 +70,7 @@ class ComponentPreloader:
         for e in engines.all():
             if hasattr(e, "engine"):
                 template_source_loaders.extend(
-                    e.engine.get_template_loaders(e.engine.loaders)
+                    e.engine.get_template_loaders(e.engine.loaders)  # type: ignore
                 )
         loaders = []
         for loader in template_source_loaders:

--- a/src/django_idom/utils.py
+++ b/src/django_idom/utils.py
@@ -6,10 +6,14 @@ import os
 import re
 from fnmatch import fnmatch
 from importlib import import_module
-from typing import Any, Callable
+from inspect import iscoroutinefunction
+from typing import Any, Callable, Sequence
 
+from channels.db import database_sync_to_async
+from django.http import HttpRequest, HttpResponse
 from django.template import engines
 from django.utils.encoding import smart_str
+from django.views import View
 
 from django_idom.config import IDOM_REGISTERED_COMPONENTS
 
@@ -28,6 +32,44 @@ COMPONENT_REGEX = re.compile(
     + _component_kwargs
     + r"\s*%}"
 )
+
+
+async def render_view(
+    view: Callable | View,
+    request: HttpRequest,
+    args: Sequence,
+    kwargs: dict,
+) -> HttpResponse:
+    """Ingests a Django view (class or function) and returns an HTTP response object."""
+    # Render Check 1: Async function view
+    if iscoroutinefunction(view) and callable(view):
+        response = await view(request, *args, **kwargs)
+
+    # Render Check 2: Async class view
+    elif getattr(view, "view_is_async", False):
+        # django-stubs does not support async views yet, so we have to ignore types here
+        view_or_template_view = await view.as_view()(request, *args, **kwargs)  # type: ignore
+        if getattr(view_or_template_view, "render", None):  # TemplateView
+            response = await view_or_template_view.render()
+        else:  # View
+            response = view_or_template_view
+
+    # Render Check 3: Sync class view
+    elif getattr(view, "as_view", None):
+        # MyPy does not know how to properly interpret this as a `View` type
+        # And `isinstance(view, View)` does not work due to some weird Django internal shenanigans
+        async_cbv = database_sync_to_async(view.as_view())  # type: ignore
+        view_or_template_view = await async_cbv(request, *args, **kwargs)
+        if getattr(view_or_template_view, "render", None):  # TemplateView
+            response = await database_sync_to_async(view_or_template_view.render)()
+        else:  # View
+            response = view_or_template_view
+
+    # Render Check 4: Sync function view
+    else:
+        response = await database_sync_to_async(view)(request, *args, **kwargs)
+
+    return response
 
 
 def _register_component(dotted_path: str) -> None:

--- a/src/django_idom/websocket/consumer.py
+++ b/src/django_idom/websocket/consumer.py
@@ -71,7 +71,7 @@ class IdomAsyncWebsocketConsumer(AsyncJsonWebsocketConsumer):
             )
             return
 
-        self._idom_recv_queue = recv_queue = asyncio.Queue()
+        self._idom_recv_queue = recv_queue = asyncio.Queue()  # type: ignore
         try:
             await serve_json_patch(
                 Layout(WebsocketContext(component_instance, value=socket)),

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from .models import TodoItem
+from test_app.models import TodoItem
 
 
 @admin.register(TodoItem)

--- a/tests/test_app/admin.py
+++ b/tests/test_app/admin.py
@@ -1,5 +1,4 @@
 from django.contrib import admin
-
 from test_app.models import TodoItem
 
 

--- a/tests/test_app/components.py
+++ b/tests/test_app/components.py
@@ -200,7 +200,7 @@ def todo_list():
     elif add_item.error:
         mutation_status = html.h2(f"Error when adding - {add_item.error}")
     else:
-        mutation_status = ""
+        mutation_status = ""  # type: ignore
 
     def on_submit(event):
         if event["key"] == "Enter":
@@ -279,7 +279,7 @@ _view_to_component_kwargs = view_to_component(views.view_to_component_kwargs)
 @component
 def view_to_component_sync_func_compatibility():
     return html.div(
-        {"id": inspect.currentframe().f_code.co_name},
+        {"id": inspect.currentframe().f_code.co_name},  # type: ignore
         _view_to_component_sync_func_compatibility(key="test"),
         html.hr(),
     )
@@ -288,7 +288,7 @@ def view_to_component_sync_func_compatibility():
 @component
 def view_to_component_async_func_compatibility():
     return html.div(
-        {"id": inspect.currentframe().f_code.co_name},
+        {"id": inspect.currentframe().f_code.co_name},  # type: ignore
         _view_to_component_async_func_compatibility(),
         html.hr(),
     )
@@ -297,7 +297,7 @@ def view_to_component_async_func_compatibility():
 @component
 def view_to_component_sync_class_compatibility():
     return html.div(
-        {"id": inspect.currentframe().f_code.co_name},
+        {"id": inspect.currentframe().f_code.co_name},  # type: ignore
         _view_to_component_sync_class_compatibility(),
         html.hr(),
     )
@@ -306,7 +306,7 @@ def view_to_component_sync_class_compatibility():
 @component
 def view_to_component_async_class_compatibility():
     return html.div(
-        {"id": inspect.currentframe().f_code.co_name},
+        {"id": inspect.currentframe().f_code.co_name},  # type: ignore
         _view_to_component_async_class_compatibility(),
         html.hr(),
     )
@@ -315,7 +315,7 @@ def view_to_component_async_class_compatibility():
 @component
 def view_to_component_template_view_class_compatibility():
     return html.div(
-        {"id": inspect.currentframe().f_code.co_name},
+        {"id": inspect.currentframe().f_code.co_name},  # type: ignore
         _view_to_component_template_view_class_compatibility(),
         html.hr(),
     )
@@ -328,11 +328,11 @@ def view_to_component_request():
     def on_click(_):
         post_request = HttpRequest()
         post_request.method = "POST"
-        set_request(post_request)
+        set_request(post_request)  # type: ignore
 
     return html._(
         html.button(
-            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},
+            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},  # type: ignore
             "Click me",
         ),
         _view_to_component_request(request=request),
@@ -348,7 +348,7 @@ def view_to_component_args():
 
     return html._(
         html.button(
-            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},
+            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},  # type: ignore
             "Click me",
         ),
         _view_to_component_args(None, success),
@@ -364,7 +364,7 @@ def view_to_component_kwargs():
 
     return html._(
         html.button(
-            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},
+            {"id": f"{inspect.currentframe().f_code.co_name}_btn", "onClick": on_click},  # type: ignore
             "Click me",
         ),
         _view_to_component_kwargs(success=success),
@@ -376,7 +376,7 @@ def view_to_component_decorator(request):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type: ignore
     )
 
 
@@ -385,5 +385,5 @@ def view_to_component_decorator_args(request):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type: ignore
     )

--- a/tests/test_app/migrations/0001_initial.py
+++ b/tests/test_app/migrations/0001_initial.py
@@ -7,16 +7,23 @@ class Migration(migrations.Migration):
 
     initial = True
 
-    dependencies = [
-    ]
+    dependencies = []  # type: ignore
 
     operations = [
         migrations.CreateModel(
-            name='TodoItem',
+            name="TodoItem",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('done', models.BooleanField()),
-                ('text', models.CharField(max_length=1000)),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("done", models.BooleanField()),
+                ("text", models.CharField(max_length=1000)),
             ],
         ),
     ]

--- a/tests/test_app/models.py
+++ b/tests/test_app/models.py
@@ -2,5 +2,5 @@ from django.db import models
 
 
 class TodoItem(models.Model):
-    done = models.BooleanField()
-    text = models.CharField(max_length=1000)
+    done = models.BooleanField()  # type: ignore
+    text = models.CharField(max_length=1000)  # type: ignore

--- a/tests/test_app/settings.py
+++ b/tests/test_app/settings.py
@@ -30,6 +30,7 @@ ALLOWED_HOSTS = ["*"]
 
 # Application definition
 INSTALLED_APPS = [
+    "daphne",  # Overrides `runserver` command with an ASGI server
     "django.contrib.admin",
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/tests/test_app/urls.py
+++ b/tests/test_app/urls.py
@@ -27,7 +27,7 @@ class AccessUser:
     has_module_perms = has_perm = __getattr__ = lambda s, *a, **kw: True
 
 
-admin.site.has_permission = lambda r: setattr(r, "user", AccessUser()) or True
+admin.site.has_permission = lambda r: setattr(r, "user", AccessUser()) or True  # type: ignore
 
 urlpatterns = [
     path("", base_template),

--- a/tests/test_app/views.py
+++ b/tests/test_app/views.py
@@ -6,15 +6,14 @@ from django.views.generic import TemplateView, View
 
 
 def base_template(request):
-    context = {}
-    return render(request, "base.html", context)
+    return render(request, "base.html", {})
 
 
 def view_to_component_sync_func(request):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type:ignore
     )
 
 
@@ -22,7 +21,7 @@ async def view_to_component_async_func(request):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type:ignore
     )
 
 
@@ -55,7 +54,7 @@ def view_to_component_sync_func_compatibility(request):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type:ignore
     )
 
 
@@ -63,7 +62,7 @@ async def view_to_component_async_func_compatibility(request):
     return await database_sync_to_async(render)(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name},
+        {"test_name": inspect.currentframe().f_code.co_name},  # type:ignore
     )
 
 
@@ -97,7 +96,7 @@ def view_to_component_script(request):
         request,
         "view_to_component_script.html",
         {
-            "test_name": inspect.currentframe().f_code.co_name,
+            "test_name": inspect.currentframe().f_code.co_name,  # type:ignore
             "status": "false",
         },
     )
@@ -108,14 +107,14 @@ def view_to_component_request(request):
         return render(
             request,
             "view_to_component.html",
-            {"test_name": inspect.currentframe().f_code.co_name},
+            {"test_name": inspect.currentframe().f_code.co_name},  # type:ignore
         )
 
     return render(
         request,
         "view_to_component.html",
         {
-            "test_name": inspect.currentframe().f_code.co_name,
+            "test_name": inspect.currentframe().f_code.co_name,  # type:ignore
             "status": "false",
             "success": "false",
         },
@@ -126,7 +125,10 @@ def view_to_component_args(request, success):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name, "status": success},
+        {
+            "test_name": inspect.currentframe().f_code.co_name,  # type:ignore
+            "status": success,
+        },
     )
 
 
@@ -134,5 +136,8 @@ def view_to_component_kwargs(request, success="false"):
     return render(
         request,
         "view_to_component.html",
-        {"test_name": inspect.currentframe().f_code.co_name, "status": success},
+        {
+            "test_name": inspect.currentframe().f_code.co_name,  # type:ignore
+            "status": success,
+        },
     )


### PR DESCRIPTION
## Changelog

- Change type hint on `view_to_component` callable to have `request` argument be optional.
- More DRY way of async view rendering.
- Have docs demonstrate how to use Django-IDOM with `channels>=4.0.0`.
- Concatenate some examples on the `view_to_component` docs
- Add note to docs about potential information exposure via `view_to_component` when using `compatibility=True`.
- Clean up docs on running tests

## Checklist:

Please update this checklist as you complete each item:

-   [x] Tests have been included for all bug fixes or added functionality.
-   [x] The `changelog.rst` has been updated with any significant changes, if necessary.
-   [x] GitHub Issues which may be closed by this PR have been linked.
